### PR TITLE
Move to an architecture closer to Redux

### DIFF
--- a/dev/Results.js
+++ b/dev/Results.js
@@ -6,7 +6,9 @@ function Results(props) {
   const hits = (props.results.hits || []).map((hit) => {
     return <div key={hit.objectID}>{hit.Name}</div>;
   });
-  return <div>{hits}</div>; 
+  return <div>{hits}</div>;
 }
 
-export default connect(Results);
+export default connect(state => ({
+  results: state.searchResults,
+}))(Results);

--- a/dev/SearchBox.js
+++ b/dev/SearchBox.js
@@ -1,6 +1,6 @@
 import React, {Component, PropTypes as T} from 'react';
 import connect from '../src/connect.js';
 
-export default connect(function({helper}) {
+export default connect()(function({helper}) {
   return <input onChange={(e) => helper.setQuery(e.target.value).search()} />;
 });

--- a/dev/index.js
+++ b/dev/index.js
@@ -1,20 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import App from './App';
-
+import algoliasearch from 'algoliasearch';
+import algoliasearchHelper from 'algoliasearch-helper';
 import Provider from '../src/Provider.js';
 
-const algoliaCredentials = {
-  applicationID: 'latency',
-  key: 'ffc36feb6e9df06e1c3c4549b5af2b31'
-};
+import App from './App';
 
-const helperConfig = {
-  index: 'starbucks'
-};
+const client = algoliasearch('latency', 'ffc36feb6e9df06e1c3c4549b5af2b31');
+const helper = algoliasearchHelper(client, 'starbucks');
 
 ReactDOM.render(
-  <Provider credentials={algoliaCredentials} config={helperConfig}>
+  <Provider helper={helper}>
     <App />
   </Provider>,
-  document.getElementById('root'));
+  document.getElementById('root')
+);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "algoliaseach-helper-provider",
+  "name": "algoliasearch-helper-provider",
   "version": "1.0.0",
   "description": "",
   "scripts": {
@@ -10,12 +10,13 @@
     "type": "git",
     "url": ""
   },
-  "keywords": [
-  ],
+  "keywords": [],
   "author": "",
   "license": "MIT",
   "homepage": "",
   "devDependencies": {
+    "algoliasearch": "*",
+    "algoliasearch-helper": "*",
     "babel-core": "*",
     "babel-eslint": "*",
     "babel-loader": "*",
@@ -24,15 +25,17 @@
     "babel-preset-stage-0": "*",
     "eslint": "*",
     "eslint-plugin-react": "*",
+    "react": "*",
+    "react-addons-shallow-compare": "^15.2.0",
+    "react-dom": "*",
     "react-hot-loader": "*",
     "webpack": "*",
     "webpack-dev-server": "*"
   },
-  "dependencies": {
+  "peerDependencies": {
     "algoliasearch": "*",
     "algoliasearch-helper": "*",
-    "lodash": "^4.13.1",
     "react": "*",
-    "react-dom": "*"
+    "react-addons-shallow-compare": "^15.2.0"
   }
 }

--- a/src/Provider.js
+++ b/src/Provider.js
@@ -1,54 +1,33 @@
-import React, {Component, PropTypes as T, Children} from 'react';
-import AlgoliaSearchHelper from 'algoliasearch-helper';
-import Algoliasearch from 'algoliasearch';
-import bindAll from 'lodash/bindAll';
+import React, { Component, PropTypes as T, Children } from 'react';
+import { AlgoliaSearchHelper } from 'algoliasearch-helper';
 
-export const contextType = {
-  helper: T.object.isRequired,
-  results: T.object
-};
+import createStore from './createStore';
+import storeShape from './storeShape';
 
-export default class Provider extends Component {
+class Provider extends Component {
   static propTypes = {
-    credentials: T.shape({
-      applicationID: T.string.isRequired,
-      key: T.string.isRequired
-    }),
-    config: T.shape({
-      index: T.string.isRequired,
-      facets: T.arrayOf(T.string),
-      disjunctiveFacets: T.arrayOf(T.string)
-    })
-  }
+    helper: T.instanceOf(AlgoliaSearchHelper),
+  };
 
-  static childContextTypes = contextType;
+  static childContextTypes = {
+    algoliaStore: storeShape.isRequired,
+  };
 
   constructor(props) {
     super(props);
-    this.state = { lastSearchResults: {} };
+
+    this.store = createStore(props.helper);
   }
 
-  componentDidMount() {
-    this.helper.search();
-  }
-
-  getChildContext(){
-    const client = Algoliasearch(this.props.credentials.applicationID, this.props.credentials.key);
-    const helper = this.helper = bindAll(AlgoliaSearchHelper(client, this.props.config.index, {
-      facets: this.props.config.facets, disjunctiveFacets: this.props.config.disjunctiveFacets
-    }));
-
-    helper.on('result', (res) => {
-      this.setState({lastSearchResults: res});
-    });
-
+  getChildContext() {
     return {
-      helper,
-      results: this.state.lastSearchResults
+      algoliaStore: this.store,
     };
   }
 
   render() {
     return Children.only(this.props.children);
   }
-};
+}
+
+export default Provider;

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -1,0 +1,59 @@
+export default function createStore(helper) {
+  let state = {
+    searching: false,
+    searchParameters: helper.getState(),
+    searchResults: null,
+    searchError: null,
+  };
+  const listeners = [];
+  const dispatch = () => {
+    listeners.forEach(listener => listener());
+  };
+
+  helper.on('change', searchParameters => {
+    state = {
+      ...state,
+      searchParameters,
+    };
+    dispatch();
+  });
+
+  helper.on('search', () => {
+    state = {
+      ...state,
+      searching: true,
+    };
+    dispatch();
+  });
+
+  helper.on('result', searchResults => {
+    state = {
+      ...state,
+      searching: false,
+      searchResults,
+    };
+    dispatch();
+  });
+
+  helper.on('error', searchError => {
+    state = {
+      ...state,
+      searching: false,
+      searchError,
+    };
+    dispatch();
+  });
+
+  return {
+    getHelper: () => helper,
+    getState: () => {
+      return state;
+    },
+    subscribe: listener => {
+      listeners.push(listener);
+      return () => {
+        listeners.splice(listeners.indexOf(listener));
+      };
+    },
+  };
+}

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -51,7 +51,7 @@ export default function createStore(helper) {
     },
     subscribe: listener => {
       listeners.push(listener);
-      return () => {
+      return function unsubscribe() {
         listeners.splice(listeners.indexOf(listener));
       };
     },

--- a/src/storeShape.js
+++ b/src/storeShape.js
@@ -1,0 +1,7 @@
+import { PropTypes as T } from 'react';
+
+export default T.shape({
+  getHelper: T.func.isRequired,
+  getState: T.func.isRequired,
+  subscribe: T.func.isRequired,
+});


### PR DESCRIPTION
### Provider

The Provider now accepts a `helper` prop, which is an instance of `AlgoliaSearchHelper`, instead of client credentials and helper config.

My reasoning for this is that a user of the Provider might still want to have access to the helper function if they ever need to call a method on it from the outside.

I haven't thought about what happens when the `helper` prop changes just yet, if that's a case we ever need to support.
### Store

Behind the scenes, the Provider creates a store much like a Redux store, with a `{ subscribe, getState, getHelper }` interface.

`dispatch` is not present since calling functions on the helper is functionally equivalent to dispatching an action (`helper.setQuery(query)` <==> `dispatch(setQuery(query))`). 

`getHelper` is added so that we can retrieve the helper in order to call methods on it and enable `dispatch`-like feature. The reason why it is a function is if we ever need to replace the helper (again, not sure this is useful).

The store is passed down the component chain through context, exactly like a Redux store. Since the store object itself never changes, we don't need to worry about `shouldComponentUpdate` masking context changes.

The store's state shape is:

```
{
  searching: bool, // Is a search happening right now
  searchParameters: SearchParameters,
  searchResults: SearchResults,
  searchError: Error,
}
```
### connect

`connect` now accepts a `mapToProps` function that maps the store state to props to expose to the connected component. This allows for selecting a subset of the state with intelligent shouldComponentUpdate.

For instance, when we do:

```
connect(state => ({ query: state.searchParameters.query }))(SearchBox);
```

The SearchBox component will only ever get re-rendered when the `state.searchParameters.query` actually changes (unless of course its parent passes on different props in a re-render).

`connect` also accepts a `helperProp` string in case the user wants to change the name of the prop that contains the helper on the connected component. Not sure this is really useful.
### Misc.

Following the Redux comparison, our helper already acts as a store. We could pass it in context directly but I don't think it has methods to retrieve the `searching` and `searchResults` state values.

I've moved react and algolia dependencies to peerDependencies since the user will have to have installed them (except for ReactDOM which we don't actually depend on as a library). I've also duplicated them into devDependencies so that they'll be installed on `npm install`.

I think that's all for now.
