### PR TITLE
Debounced search and dispatch

### DIFF
--- a/dev/SearchBox.js
+++ b/dev/SearchBox.js
@@ -1,6 +1,9 @@
 import React, {Component, PropTypes as T} from 'react';
 import connect from '../src/connect.js';
 
-export default connect()(function({helper}) {
-  return <input onChange={(e) => helper.setQuery(e.target.value).search()} />;
+export default connect()(function({helper, search}) {
+  return <input onChange={(e) => {
+    helper.setQuery(e.target.value);
+    search();
+  }} />;
 });

--- a/src/connect.js
+++ b/src/connect.js
@@ -16,12 +16,12 @@ export default function connect(
       constructor(props, context) {
         super();
 
-        if (mapToProps) {
-          this.state = mapToProps(context.algoliaStore.getState(), props);
+        if (mapStateToProps) {
+          this.state = mapStateToProps(context.algoliaStore.getState(), props);
 
           this.unsubscribe = context.algoliaStore.subscribe(() => {
             this.setState(
-              mapToProps(context.algoliaStore.getState(), this.props)
+              mapStateToProps(context.algoliaStore.getState(), this.props)
             );
           });
         }

--- a/src/connect.js
+++ b/src/connect.js
@@ -3,7 +3,10 @@ import shallowCompare from 'react-addons-shallow-compare';
 
 import storeShape from './storeShape';
 
-export default function connect(mapToProps, helperProp = 'helper') {
+export default function connect(
+  mapStateToProps,
+  { helperProp = 'helper', searchProp = 'search' } = {}
+) {
   return Composed => {
     return class Connected extends Component {
       static contextTypes = {
@@ -39,7 +42,10 @@ export default function connect(mapToProps, helperProp = 'helper') {
           <Composed
             {...this.props}
             {...this.state}
-            {...{[helperProp]: this.context.algoliaStore.getHelper() }}
+            {...{
+              [helperProp]: this.context.algoliaStore.getHelper(),
+              [searchProp]: this.context.algoliaStore.debouncedSearch,
+            }}
           />
         );
       }

--- a/src/connect.js
+++ b/src/connect.js
@@ -27,6 +27,14 @@ export default function connect(
         }
       }
 
+      componentWillReceiveProps(nextProps) {
+        if (mapStateToProps) {
+          this.setState(
+            mapStateToProps(this.context.algoliaStore.getState(), nextProps)
+          );
+        }
+      }
+
       componentWillUnmount() {
         if (this.unsubscribe) {
           this.unsubscribe();

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -10,12 +10,34 @@ export default function createStore(helper) {
     listeners.forEach(listener => listener());
   };
 
+  let dispatchQueued = false;
+  const debouncedDispatch = () => {
+    if (!dispatchQueued) {
+      dispatchQueued = true;
+      process.nextTick(() => {
+        dispatchQueued = false;
+        dispatch();
+      });
+    }
+  };
+
+  let searchQueued = false;
+  const debouncedSearch = () => {
+    if (!searchQueued) {
+      searchQueued = true;
+      process.nextTick(() => {
+        searchQueued = false;
+        helper.search();
+      });
+    }
+  };
+
   helper.on('change', searchParameters => {
     state = {
       ...state,
       searchParameters,
     };
-    dispatch();
+    debouncedDispatch();
   });
 
   helper.on('search', () => {
@@ -45,6 +67,7 @@ export default function createStore(helper) {
   });
 
   return {
+    debouncedSearch,
     getHelper: () => helper,
     getState: () => {
       return state;


### PR DESCRIPTION
Only call dispatch and search once on a single JS frame. This allows for different components to edit the helper state and call search independently while only making a single request and render.
