### PR TITLE
feat(applied-search-params): add searchResultsSearchParameters to store state

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Every function passed to `mapStateToProps` argument of `connect` will be given a
 * `searching` (boolean): `true` when a search request is pending, false otherwise
 * `searchParameters` (object): helper's [SearchParameters](https://community.algolia.com/algoliasearch-helper-js/docs/SearchParameters.html)
 * `searchResults` (object): helper's [SearchResults](https://community.algolia.com/algoliasearch-helper-js/docs/SearchResults.html)
+* `searchResultsSearchParameters` (object): [SearchParameters](https://community.algolia.com/algoliasearch-helper-js/docs/SearchParameters.html) that yielded the current [SearchResults](https://community.algolia.com/algoliasearch-helper-js/docs/SearchResults.html)
 * `searchError` (Error): When the search fails
 
 #### Remarks

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -3,6 +3,7 @@ export default function createStore(helper) {
     searching: false,
     searchParameters: helper.getState(),
     searchResults: null,
+    searchResultsSearchParameters: null,
     searchError: null
   };
   const listeners = [];
@@ -24,11 +25,12 @@ export default function createStore(helper) {
     dispatch();
   });
 
-  helper.on('result', searchResults => {
+  helper.on('result', (searchResults, searchParameters) => {
     state = {
       ...state,
       searching: false,
-      searchResults
+      searchResults,
+      searchResultsSearchParameters: searchParameters
     };
     dispatch();
   });

--- a/src/createStore.test.js
+++ b/src/createStore.test.js
@@ -24,6 +24,7 @@ describe('createStore', () => {
       searching: false,
       searchParameters,
       searchResults: null,
+      searchResultsSearchParameters: null,
       searchError: null
     });
 
@@ -41,6 +42,7 @@ describe('createStore', () => {
       searching: false,
       searchParameters: searchParametersUpdate,
       searchResults: null,
+      searchResultsSearchParameters: null,
       searchError: null
     });
 
@@ -57,6 +59,7 @@ describe('createStore', () => {
       searching: true,
       searchParameters,
       searchResults: null,
+      searchResultsSearchParameters: null,
       searchError: null
     });
   });
@@ -67,15 +70,38 @@ describe('createStore', () => {
     const helper = new EventEmitter();
     helper.getState = () => searchParameters;
     const store = createStore(helper);
-    helper.emit('result', searchResults);
+    helper.emit('result', searchResults, searchParameters);
     expect(store.getState()).toEqual({
       searching: false,
       searchParameters,
       searchResults,
+      searchResultsSearchParameters: searchParameters,
       searchError: null
     });
 
     expect(store.getState().searchResults).toBe(searchResults);
+  });
+
+  it('stores the search parameters that yielded the search results', () => {
+    const searchResultsSearchParameters = {some: 'parameter'};
+    const searchResults = {some: 'result'};
+    const helper = new EventEmitter();
+    helper.getState = () => searchResultsSearchParameters;
+    const store = createStore(helper);
+    helper.emit('result', searchResults, searchResultsSearchParameters);
+    const searchParameters = {someOther: 'parameter'};
+    helper.emit('change', {someOther: 'parameter'});
+    expect(store.getState()).toEqual({
+      searching: false,
+      searchParameters,
+      searchResults,
+      searchResultsSearchParameters,
+      searchError: null
+    });
+
+    expect(store.getState().searchResultsSearchParameters).toBe(
+      searchResultsSearchParameters
+    );
   });
 
   it('computes state on helper error', () => {
@@ -89,6 +115,7 @@ describe('createStore', () => {
       searching: false,
       searchParameters,
       searchResults: null,
+      searchResultsSearchParameters: null,
       searchError
     });
 


### PR DESCRIPTION
The searchParameters entry represents the state of the current search, but in the time between a new search and the results event, we sometimes need to know which searchParameters yielded the current searchResults. An example of this is to provide a warning in instantsearch-react when a requested facet was not returned from the API.

Not in love with the name `searchResultsSearchParameters`.
